### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: "^1.17.0"
       - name: Run build
         run: ./build.sh
-      - uses: elgohr/Github-Release-Action@master
+      - uses: elgohr/Github-Release-Action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore